### PR TITLE
Added live preview feature

### DIFF
--- a/AlignTab.sublime-settings
+++ b/AlignTab.sublime-settings
@@ -7,5 +7,7 @@
   // disable auto_match in the input panel
   "auto_match_enabled": false,
   // Allow align tab to show changes as you type
-  "live_preview": false
+  "live_preview": false,
+  // Limit the number of lines that may be affected by live preview
+  "live_preview_limit": 1000
 }


### PR DESCRIPTION
Tested in ST3 and ST2.
Resolves feature request #20.
## Feature:

Change the `aligntab_live_preview` setting to `true` in your user preferences to enable preview-as-you-type in the AlignTab expression box. This is especially helpful if you're having troubles forming an expression.
### Implementation:
- I used `aligntab_live_preview` as the setting name in order to make it easier to set in the global user preferences _(which is where I put all my settings)_ instead of the AlignTab user preferences.
- The setting will default to false for existing installations, so as not to drive people nuts.
- The plugin uses undo since the change is a command in the history, so every time you press a character it runs `undo`, then `align_tab`. Undo doesn't get run if no change was previously made.
- When you submit the AlignTab expression, there will only be one entry added to the history (not one for every single character entered). This makes it so when using live_preview and submitting the buffer, you can still run undo as normal afterwords.
