### PR TITLE
resolve input changed checking order

### DIFF
--- a/aligntab.py
+++ b/aligntab.py
@@ -9,10 +9,10 @@ def resolve_input(user_input):
     if isinstance(user_input, str):
         s = sublime.load_settings('AlignTab.sublime-settings')
         patterns = s.get('named_patterns', {})
+        if user_input == 'last_regex' and history.last():
+            user_input = history.last()
         if user_input in patterns:
             user_input = patterns[user_input]
-        elif user_input == 'last_regex' and history.last():
-            user_input = history.last()
     if isinstance(user_input, str):
         user_input = [user_input]
     return user_input


### PR DESCRIPTION
Now in `resolve_input()` first checks if it is `'last_regex'` and then it checks if it is in `patterns`.
This way it is possible to use patterns, that are saved in the settings, with table-mode.