### PR TITLE
Start TableMode with keybind/command

### DIFF
--- a/aligntab.py
+++ b/aligntab.py
@@ -44,6 +44,8 @@ class AlignTabCommand(sublime_plugin.TextCommand):
 
                 if self.aligned:
                     if mode:
+                        # to allow keybinds for tablemode
+                        history.insert(uinput)
                         toogle_table_mode(view, True)
                     else:
                         sublime.status_message("")

--- a/aligntab.py
+++ b/aligntab.py
@@ -44,7 +44,7 @@ class AlignTabCommand(sublime_plugin.TextCommand):
 
                 if self.aligned:
                     if mode:
-                        # to allow keybinds for tablemode
+                        # to allow keybinds/commands for tablemode
                         history.insert(uinput)
                         toogle_table_mode(view, True)
                     else:


### PR DESCRIPTION
When starting in tablemode, we try to push the user input to the history. History doesn't allow multiple entries of the same input back to back, so this should be safe (tested aswell).

This allows table mode to be started by keybind/command. For example, table mode for LaTeX tables:
```json
{
  "keys": ["ctrl+-", "ctrl+l"], 
  "command": "align_tab", 
  "args": {"mode": true, "user_input": "(?<!\\\\)&|\\\\\\\\"}, 
  "context": 
    [
      { "key": "selector", "operator": "equal", "operand": "text.tex.latex" }
    ]
},
```

Closes #60.