### PR TITLE
exclude unittests from sublime-packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+## git
+*.gitignore         export-ignore
+*.gitattributes     export-ignore
+
+## unit testing
+tests/              export-ignore
+.travis.yml         export-ignore
+appveyor.yml        export-ignore
+unittesting.json    export-ignore


### PR DESCRIPTION
Unittests and their configuration files are not needed by ST, but only for development purposes. Therefore they don't need to be part of the sublime-package. This commit therefore proposes the use of an .gitattribute file to exclude those files from being added to the zip archive, which is downloaded by Package Control upon install/update.