### PR TITLE
Fixed misspelling of toggle word on aligntab.py and table.py

### DIFF
--- a/aligntab.py
+++ b/aligntab.py
@@ -1,7 +1,7 @@
 import sublime
 import sublime_plugin
 from .hist import history
-from .table import toogle_table_mode
+from .table import toggle_table_mode
 from .aligner import Aligner
 
 
@@ -49,12 +49,12 @@ class AlignTabCommand(sublime_plugin.TextCommand):
                     if mode:
                         # to allow keybinds/commands for tablemode
                         history.insert(uinput)
-                        toogle_table_mode(view, True)
+                        toggle_table_mode(view, True)
                     else:
                         sublime.status_message("")
                 else:
                     if mode and not aligner.adjacent_lines_match():
-                        toogle_table_mode(view, False)
+                        toggle_table_mode(view, False)
                     else:
                         error.append(uinput)
             if error:

--- a/table.py
+++ b/table.py
@@ -2,7 +2,7 @@ import sublime_plugin
 import threading
 
 
-def toogle_table_mode(view, on=True):
+def toggle_table_mode(view, on=True):
     if on:
         view.settings().set("AlignTabTableMode", True)
         view.set_status("aligntab", "[Table Mode]")
@@ -78,7 +78,7 @@ class AlignTabClearMode(sublime_plugin.TextCommand):
         view = self.view
         if view.is_scratch() or view.settings().get('is_widget'):
             return
-        toogle_table_mode(view, False)
+        toggle_table_mode(view, False)
 
     def is_enabled(self):
         return self.view.settings().get("AlignTabTableMode", False)


### PR DESCRIPTION
I was fixing my misspellings of the toggle word, while I found this.